### PR TITLE
Filter has been missing in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'hydra.core',
         'hydra.gen',
         'hydra.io',
+        'hydra.filter',
         'hydra.tonemap'
     ]
 )


### PR DESCRIPTION
I have downloaded and tested your tone_mapping.py example. Great work! Thanks for that. The only thing that was not working directly is that 'hydra.filter' had to be added in setup.py.