### PR TITLE
Small fixes to enable examples

### DIFF
--- a/examples/bilateral_filter.py
+++ b/examples/bilateral_filter.py
@@ -2,7 +2,7 @@ import scipy as sp
 import scipy.misc
 import matplotlib.pyplot as plt
 
-import hydra.filter
+import hydra.filters
 
 def main():
     img = sp.misc.imread('../data/lamp.jpg')
@@ -11,7 +11,7 @@ def main():
     h, w, _ = img.shape
     sigma_s = max(h, w) * 0.02
     sigma_r = 0.4
-    res = hydra.filter.bilateral(img, sigma_s, sigma_r)
+    res = hydra.filters.bilateral(img, sigma_s, sigma_r)
 
     plt.subplot(1, 2, 1)
     plt.imshow(img)

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,10 @@ setup(
     packages = [
         'hydra',
         'hydra.core',
+        'hydra.eo',
+        'hydra.filters',
         'hydra.gen',
         'hydra.io',
-        'hydra.filters',
         'hydra.tonemap'
     ]
 )


### PR DESCRIPTION
This fixes some minor typographical errors in the setup.py and bilateral_filter.py scripts that prevented some example scripts from being executed.